### PR TITLE
update 1.2.5

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -6,7 +6,7 @@ package:
 
 source:
   url: https://github.com/bagel897/pytoolconfig/archive/refs/tags/v{{ version }}.tar.gz
-  sha256: 077daa343e0b865f30eadbd2a2fc778983a526311dd44f8ae31d17ba5bc1b126
+  sha256: 2d5ee0ed520662f3a895d2890c3e25e2250e58cdf0d2ca6d9e38214a6da22bf1
 
 build:
   script: {{ PYTHON }} -m pip install . -vv

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -15,7 +15,6 @@ build:
 
 requirements:
   host:
-    - pip
     - pdm
     - pdm-pep517
     - python
@@ -43,6 +42,7 @@ about:
     Python tool configuration.
   license: LGPL-3.0-or-later
   license_family: LGPL
+  license_url: https://github.com/bagel897/pytoolconfig/blob/main/LICENSE
   doc_url: https://github.com/bagel897/pytoolconfig/blob/main/README.md
 
 extra:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -19,6 +19,8 @@ requirements:
     - pdm
     - pdm-pep517 >=1.0.5
     - python
+    - setuptools
+    - wheel
   run:
     - packaging >=22.0
     - python
@@ -34,10 +36,15 @@ test:
     - pip
 
 about:
-  home: https://pypi.org/project/pytoolconfig
+  home: https://github.com/bagel897/pytoolconfig
+  dev_url: https://github.com/bagel897/pytoolconfig
   summary: Python tool configuration
+  description: |
+    Python tool configuration.
   license: LGPL-3.0-or-later
   license_file: LICENSE
+  license_url: https://github.com/bagel897/pytoolconfig/blob/main/LICENSE
+  doc_url: https://github.com/bagel897/pytoolconfig/blob/main/README.md
 
 extra:
   recipe-maintainers:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,12 +9,13 @@ source:
   sha256: 077daa343e0b865f30eadbd2a2fc778983a526311dd44f8ae31d17ba5bc1b126
 
 build:
-  script: {{ PYTHON }} -m pip install . -vv
+  script: {{ PYTHON }} -m pip install . -vv --no-deps
   skip: True # [py<37]
   number: 0
 
 requirements:
   host:
+    - pip
     - pdm
     - pdm-pep517
     - python

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,29 +1,29 @@
-{% set version = "1.2.4" %}
+{% set version = "1.2.5" %}
 
 package:
   name: pytoolconfig
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/p/pytoolconfig/pytoolconfig-{{ version }}.tar.gz
-  sha256: 5e1a246f77970ddb5f3d8d06fbf162424b8a1adfc22c2eb51826b383bf293d1e
+  url: https://github.com/bagel897/pytoolconfig/archive/refs/tags/v{{ version }}.tar.gz
+  sha256: 077daa343e0b865f30eadbd2a2fc778983a526311dd44f8ae31d17ba5bc1b126
 
 build:
   script: {{ PYTHON }} -m pip install . -vv
-  noarch: python
-  number: 1
+  skip: True # [py<37]
+  number: 0
 
 requirements:
   host:
-    - pip <22
+    - pip
     - pdm
     - pdm-pep517 >=1.0.5
-    - python >=3.7
+    - python
   run:
     - packaging >=22.0
-    - python >=3.7
-    - tomli >=2.0.1
-    - typing-extensions >=4.4.0
+    - python
+    - tomli >=1.2.3  # [py<311]
+    - typing-extensions >=4.4.0  # [py<38]
 
 test:
   imports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -6,7 +6,7 @@ package:
 
 source:
   url: https://github.com/bagel897/pytoolconfig/archive/refs/tags/v{{ version }}.tar.gz
-  sha256: 2d5ee0ed520662f3a895d2890c3e25e2250e58cdf0d2ca6d9e38214a6da22bf1
+  sha256: 077daa343e0b865f30eadbd2a2fc778983a526311dd44f8ae31d17ba5bc1b126
 
 build:
   script: {{ PYTHON }} -m pip install . -vv

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -17,14 +17,14 @@ requirements:
   host:
     - pip
     - pdm
-    - pdm-pep517 >=1.0.5
+    - pdm-pep517
     - python
     - setuptools
     - wheel
   run:
     - packaging >=22.0
     - python
-    - tomli >=1.2.3  # [py<311]
+    - tomli >=2.0.1  # [py<311]
     - typing-extensions >=4.4.0  # [py<38]
 
 test:
@@ -42,8 +42,7 @@ about:
   description: |
     Python tool configuration.
   license: LGPL-3.0-or-later
-  license_file: LICENSE
-  license_url: https://github.com/bagel897/pytoolconfig/blob/main/LICENSE
+  license_family: LGPL
   doc_url: https://github.com/bagel897/pytoolconfig/blob/main/README.md
 
 extra:


### PR DESCRIPTION
## Version Bump to 1.2.5
- [Jira Ticket](https://anaconda.atlassian.net/browse/PKG-1046)
- [Upstream](https://github.com/bagel897/pytoolconfig)
- [Upstream Requirements](https://github.com/bagel897/pytoolconfig/blob/main/pyproject.toml)
# Changes
- Updated `checksum` and version number
- Added skip true to `python` versions less than 3.7
- Updated required dependencies and pinnings
- Added additional information to the` about` section